### PR TITLE
Added pkg-config to default set of packages

### DIFF
--- a/arm/Dockerfile
+++ b/arm/Dockerfile
@@ -27,6 +27,7 @@ RUN mv /tmp/.cargo $HOME && \
     build-essential \
     ca-certificates \
     file \
+    pkg-config \
     curl \
     libssl-dev \
     libssl-dev:armhf && \


### PR DESCRIPTION
This is to include the pkg-config tools that are sometimes required to build openssl in some packages:

``` 
$ sudo docker run -it --rm   -v $(pwd):/source -e PKG_CONFIG_ALLOW_CROSS=1  dlecan/rust-crosscompiler-arm:stable
    Updating registry `https://github.com/rust-lang/crates.io-index`
 Downloading toml v0.4.5
 Downloading clap v2.26.2
 Downloading mqtt-protocol v0.4.2
 Downloading serde_derive v1.0.15
 Downloading native-tls v0.1.4
 Downloading serde v1.0.15
 Downloading atty v0.2.3
 Downloading ansi_term v0.9.0
 Downloading textwrap v0.8.0
 Downloading strsim v0.6.0
 Downloading vec_map v0.8.0
 Downloading bitflags v0.9.1
 Downloading term_size v0.3.0
 Downloading unicode-width v0.1.4
 Downloading lazy_static v0.2.9
 Downloading byteorder v1.1.0
 Downloading regex v0.2.2
 Downloading log v0.3.8
 Downloading memchr v1.0.1
 Downloading regex-syntax v0.4.1
 Downloading aho-corasick v0.6.3
 Downloading utf8-ranges v1.0.0
 Downloading thread_local v0.3.4
 Downloading libc v0.2.32
 Downloading unreachable v1.0.0
 Downloading void v1.0.2
 Downloading serde_derive_internals v0.16.0
 Downloading quote v0.3.15
 Downloading syn v0.11.11
 Downloading synom v0.11.3
 Downloading unicode-xid v0.0.4
 Downloading openssl v0.9.20
 Downloading foreign-types v0.2.0
 Downloading openssl-sys v0.9.20
 Downloading cc v1.0.1
 Downloading pkg-config v0.3.9
   Compiling openssl-sys v0.9.20
   Compiling serde_derive_internals v0.16.0
   Compiling regex v0.2.2
   Compiling clap v2.26.2
error: failed to run custom build command for `openssl-sys v0.9.20`
process didn't exit successfully: `/source/target/release/build/openssl-sys-ece041a505259e80/build-script-build` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=ARM_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_DIR
cargo:rerun-if-env-changed=OPENSSL_DIR
run pkg_config fail: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"`: No such file or directory (os error 2)"

--- stderr
thread 'main' panicked at '

Could not find directory of OpenSSL installation, and this `-sys` crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.

If you're in a situation where you think the directory *should* be found
automatically, please open a bug at https://github.com/sfackler/rust-openssl
and include information about your system as well as this message.

    $HOST = x86_64-unknown-linux-gnu
    $TARGET = arm-unknown-linux-gnueabihf
    openssl-sys = 0.9.20


It looks like you're compiling on Linux and also targeting Linux. Currently this
requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
could not be found. If you have OpenSSL installed you can likely fix this by
installing `pkg-config`.

', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.20/build.rs:210:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed

```